### PR TITLE
Fix failed Win unittest on colorama

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests


### PR DESCRIPTION
Applying [this](https://github.com/dwave-examples/tour-planning/pull/57/commits/4db9cf3f2013c5ad3076234a3657955978d41df8) same fix here. Unittests also show as failed on MacOS but I think that is expected today due to "Intel macOS resource brownout June 20th 00:00 - 24:00 UTC"

![image](https://github.com/dwave-examples/kibble-zurek/assets/34041130/ea6513e1-09bb-4005-923a-9efede7f0bd7)
 